### PR TITLE
remove fallback in XUserReadProfileSettings

### DIFF
--- a/dlls/xlive/main.c
+++ b/dlls/xlive/main.c
@@ -1708,7 +1708,6 @@ INT WINAPI XUserReadProfileSettings(DWORD dwTitleId, DWORD dwUserIndex, DWORD dw
         propFile = CreateFileA(path,GENERIC_READ,FILE_SHARE_READ,NULL,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,NULL);
         if ( propFile == INVALID_HANDLE_VALUE ) {
             ERR("Setting ID: %d : Cannot load property\n",id);
-            pResults->pSettings = (BYTE *)pResults+sizeof (XUSER_PROFILE_SETTING);
             continue;
         }
 

--- a/dlls/xlive/main.c
+++ b/dlls/xlive/main.c
@@ -1708,14 +1708,8 @@ INT WINAPI XUserReadProfileSettings(DWORD dwTitleId, DWORD dwUserIndex, DWORD dw
         propFile = CreateFileA(path,GENERIC_READ,FILE_SHARE_READ,NULL,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,NULL);
         if ( propFile == INVALID_HANDLE_VALUE ) {
             ERR("Setting ID: %d : Cannot load property\n",id);
-            // fallback
-            if (*pcbResults < sizeof(DWORD)+sizeof(XUSER_PROFILE_SETTING)*dwNumSettingIds) {
-                *pcbResults = sizeof(DWORD)+sizeof(XUSER_PROFILE_SETTING)*dwNumSettingIds; /* TODO: make correct calculation by IDs.*/
-            }
-            memset (pResults, 0, *pcbResults);
-            pResults->dwSettingsLen = *pcbResults-sizeof (XUSER_PROFILE_SETTING);
             pResults->pSettings = (BYTE *)pResults+sizeof (XUSER_PROFILE_SETTING);
-            return 0;
+            continue;
         }
 
 // XUSER_DATA_TYPE_CONTEXT     ((BYTE)0)


### PR DESCRIPTION
was from Onaro, to fix Viva Pinata I think, but really should not be needed. 
